### PR TITLE
Update BranchNode.tsx to use ">=" for disable on max nodes condition

### DIFF
--- a/src/Nodes/BranchNode.tsx
+++ b/src/Nodes/BranchNode.tsx
@@ -91,7 +91,7 @@ const BranchNode: React.FC<IProps> = (props) => {
 
   const disabled =
     typeof registerNode?.conditionMaxNum === 'number'
-      ? conditionCount === registerNode?.conditionMaxNum
+      ? conditionCount >= registerNode?.conditionMaxNum
       : false;
 
   const droppable = dragType && registerNode?.conditionNodeType === dragType;


### PR DESCRIPTION
In some cases more then the max nodes are added to the branch node using other means then the add buttons. In this case, the add button should also be disabled.

Having more then the max nodes, allows adding of even more nodes.