### PR TITLE
Add initialConditionNum for branch node initialization

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,7 @@ export interface IRegisterNode {
   isLoop?: boolean;
   configTitle?: string | ((node: INode, nodes: INode[]) => string);
   initialNodeData?: Record<string, any>;
+  initialConditionNum?: number;
   showPracticalBranchNode?: boolean;
   showPracticalBranchRemove?: boolean;
   className?: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,21 +94,28 @@ export const createNewNode = (
   const initialNodeData = cloneDeep(registerNode?.initialNodeData || {});
 
   const extraProps: any = isBranchNode
-    ? {
-        children: [
-          createNewNode(
-            registerNodes,
-            registerNode.conditionNodeType,
-            customCreateUuid,
-          ),
-          createNewNode(
-            registerNodes,
-            registerNode.conditionNodeType,
-            customCreateUuid,
-          ),
-        ],
-        ...initialNodeData,
-      }
+    ? ((): any => {
+        const count =
+          typeof registerNode?.initialConditionNum === 'number'
+            ? registerNode.initialConditionNum
+            : 2;
+
+        const children = [] as any[];
+        for (let i = 0; i < count; i++) {
+          children.push(
+            createNewNode(
+              registerNodes,
+              registerNode.conditionNodeType,
+              customCreateUuid,
+            ),
+          );
+        }
+
+        return {
+          children,
+          ...initialNodeData,
+        };
+      })()
     : isConditionNode || isLoopNode
     ? {
         children: [],


### PR DESCRIPTION
This change introduces initialConditionNum, which defines the number of condition children created when a new branch node is instantiated.

Previously, branch nodes were initialized with a fixed default number of children. This update makes that behavior configurable, allowing better control over initial branch structure.

If not specified, the default value remains 2.